### PR TITLE
📝 Add Accessing Observability Platform page

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,13 +3,14 @@ collapsible_nav: true
 default_owner_slack: "#observability-platform"
 enable_search: true
 footer_links:
-  Platform Status: https://status.observability-platform.service.justice.gov.uk
+  Slack: https://moj.enterprise.slack.com/archives/C05QXHR697S
+  Status: https://status.observability-platform.service.justice.gov.uk
 full_service_name: Observability Platform User Guide
 github_branch: main
 github_repo: ministryofjustice/observability-platform
 header_links:
-  GitHub: https://github.com/ministryofjustice/observability-platform-user-guide
   Slack: https://moj.enterprise.slack.com/archives/C05QXHR697S
+  Status: https://status.observability-platform.service.justice.gov.uk
 host: https://user-guide.observability-platform.service.justice.gov.uk
 max_toc_heading_level: 3
 owner_slack_workspace: mojdt

--- a/source/documentation/getting-started/accessing.html.md.erb
+++ b/source/documentation/getting-started/accessing.html.md.erb
@@ -1,0 +1,26 @@
+---
+title: Accessing Observability Platform
+last_reviewed_on: 2024-04-16
+review_in: 3 months
+weight: 0
+---
+
+# <%= current_page.data.title %>
+
+## Overview
+
+Once you have finished [onboarding to Observability Platform](/documentation/getting-started/onboarding.html), you can access Grafana by using the [AWS access portal](https://moj.awsapps.com/start/#/?tab=applications).
+
+## Using Grafana
+
+As a tenant, you will have access to:
+
+* Your onboarded AWS data sources
+
+* Your onboarded PagerDuty integrations and/or Slack channels
+
+* A GitHub data source
+
+* A folder to create dashboards and alerts
+
+For comprehensive documentation, please refer to [Grafana Labs' documentation site](https://grafana.com/docs/grafana/v9.4/).

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -19,6 +19,8 @@ This documentation is for teams who wish to integrate their applications and env
 
 - [Onboarding to Observability Platform](/documentation/getting-started/onboarding.html)
 
+- [Accessing Observability Platform](/documentation/getting-started/accessing.html)
+
 ## Getting Help
 
 You can contact us on Slack via [#ask-observability-platform](https://moj.enterprise.slack.com/archives/C05QXHR697S).


### PR DESCRIPTION
This pull request:

- Adds a page called "Accessing Observability Platform"
- Update header and footer links

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 